### PR TITLE
Fix typo in Tcp example

### DIFF
--- a/guide-async.md
+++ b/guide-async.md
@@ -156,7 +156,7 @@ let connect_or_use_cached ~cache host_and_port =
   let connect () =
     let host = Host_and_port.host host_and_port in
     let port = Host_and_port.port host_and_port in
-    Tc.connect ~host ~port ()
+    Tcp.connect ~host ~port ()
   in
   Monitor.try_with connect >>= function
   | Ok (reader, writer) ->


### PR DESCRIPTION
Tcp example has a typo in it.
