### PR TITLE
fix redirect without javascript

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="en-US">
     <head>
         <meta charset="UTF-8">
-        <meta http-equiv="refresh" content="0; url=http://example.com">
+        <meta http-equiv="refresh" content="0; url=https://opensource.janestreet.com">
         <script type="text/javascript">
             window.location.href = "https://opensource.janestreet.com"
         </script>


### PR DESCRIPTION
I block JavaScript by default at home. As such, the window.location thing wasn't firing, which was allowed the meta refresh thing to fire... sending me to www.example.com

This fixes it to not do that!